### PR TITLE
Replace deprecated `get_currentuserinfo` with `wp_get_current_user`

### DIFF
--- a/src/class-helpscout-beacon-identifier.php
+++ b/src/class-helpscout-beacon-identifier.php
@@ -97,8 +97,7 @@ class Yoast_HelpScout_Beacon_Identifier {
 	 * @return string
 	 */
 	private function get_user_info( $what = 'name' ) {
-		global $current_user;
-		get_currentuserinfo();
+		$current_user = wp_get_current_user();
 
 		switch ( $what ) {
 			case 'email':


### PR DESCRIPTION
In WordPress 4.5 get_currentuserinfo will be deprecated. See: https://core.trac.wordpress.org/ticket/19615

We should use wp_get_current_user instead