### PR TITLE
beacon configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea/

--- a/src/class-helpscout-beacon.php
+++ b/src/class-helpscout-beacon.php
@@ -9,6 +9,8 @@
 class Yoast_HelpScout_Beacon {
 
 	const YST_SEO_SUPPORT_IDENTIFY = 'yst_seo_support_identify';
+	const BEACON_TYPE_NO_SEARCH = 'no_search';
+	const BEACON_TYPE_SEARCH =  'search';
 
 	/**
 	 * @var string The current opened page without the prefix.
@@ -25,15 +27,20 @@ class Yoast_HelpScout_Beacon {
 	 */
 	protected $settings;
 
+	/** @var string The type of beacon (BEACON_TYPE_NO_SEARCH | BEACON_TYPE_SEARCH) */
+	protected $type;
+
 	/**
 	 * Setting the hook to load the beacon
 	 *
 	 * @param string                           $current_page The current opened page without the prefix.
-	 * @param Yoast_HelpScout_Beacon_Setting[] $settings  Suggestions for the admin pages.
+	 * @param Yoast_HelpScout_Beacon_Setting[] $settings     Suggestions for the admin pages.
+	 * @param string                           $type         The type of beacon to create. (BEACON_TYPE_NO_SEARCH | BEACON_TYPE_SEARCH)
 	 */
-	public function __construct( $current_page, array $settings ) {
+	public function __construct( $current_page, array $settings, $type = self::BEACON_TYPE_SEARCH ) {
 		$this->current_page = $current_page;
 		$this->settings     = $settings;
+		$this->type         = $type;
 	}
 
 	/**
@@ -54,6 +61,7 @@ class Yoast_HelpScout_Beacon {
 	 * Outputs a small piece of javascript for the beacon
 	 */
 	public function output_beacon_js() {
+		/** @noinspection PhpUnusedLocalVariableInspection */
 		$data = wp_json_encode( $this->localize_beacon() );
 
 		echo '<script type="text/javascript">';
@@ -68,15 +76,10 @@ class Yoast_HelpScout_Beacon {
 	 */
 	private function localize_beacon() {
 		return array(
-			'config' => array(
-				'instructions' => $this->get_instructions(),
-				'icon'         => 'question',
-				'color'        => '#A4286A',
-				'poweredBy'    => false,
-				'translation'  => $this->get_translations(),
-			),
+			'config'   => $this->get_config( $this->current_page ),
 			'identify' => $this->get_identify(),
 			'suggest'  => $this->get_suggest( $this->current_page ),
+			'type'     => $this->get_type(),
 		);
 	}
 
@@ -191,5 +194,31 @@ class Yoast_HelpScout_Beacon {
 		}
 
 		return $products;
+	}
+
+	/**
+	 * Returns the type of the beacon.
+	 *
+	 * @return string
+	 */
+	private function get_type(){
+		return $this->type;
+	}
+
+	private function get_config( $page ) {
+		// defaults
+		$config = array(
+			'instructions' => $this->get_instructions(),
+			'icon'         => 'question',
+			'color'        => '#A4286A',
+			'poweredBy'    => false,
+			'translation'  => $this->get_translations(),
+		);
+
+		foreach ( $this->settings as $setting ) {
+			$config = array_merge( $config, $setting->get_config( $page ) );
+		}
+
+		return $config;
 	}
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -8,6 +8,7 @@ if ( ! function_exists( 'yoast_get_helpscout_beacon' ) ) {
 	 * Retrieve the instance of the beacon
 	 *
 	 * @param string $page The current admin page.
+	 * @param string $type Which type of popup we want to show.
 	 *
 	 * @return Yoast_HelpScout_Beacon
 	 */

--- a/src/functions.php
+++ b/src/functions.php
@@ -11,11 +11,11 @@ if ( ! function_exists( 'yoast_get_helpscout_beacon' ) ) {
 	 *
 	 * @return Yoast_HelpScout_Beacon
 	 */
-	function yoast_get_helpscout_beacon( $page ) {
+	function yoast_get_helpscout_beacon( $page, $type = Yoast_HelpScout_Beacon::BEACON_TYPE_SEARCH ) {
 		static $beacon;
 
 		if ( ! isset( $beacon ) ) {
-			$beacon = new Yoast_HelpScout_Beacon( $page, array() );
+			$beacon = new Yoast_HelpScout_Beacon( $page, array(), $type );
 		}
 
 		return $beacon;

--- a/src/interface-helpscout-beacon-setting.php
+++ b/src/interface-helpscout-beacon-setting.php
@@ -19,4 +19,14 @@ interface Yoast_HelpScout_Beacon_Setting {
 	 * @return Yoast_Product[] A product to use for sending data to helpscout
 	 */
 	public function get_products( $page );
+
+
+	/**
+	 * Returns a list of config values for a a certain admin page.
+	 *
+	 * @param string $page The current admin page we are on.
+	 *
+	 * @return array A list with configuration for the beacon
+	 */
+	public function get_config( $page );
 }

--- a/src/yoast-seo-helpscout-beacon.js.php
+++ b/src/yoast-seo-helpscout-beacon.js.php
@@ -9,17 +9,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 (function(){
 	'use strict';
 
-	var wpseoHelpscoutBeaconL10n = <?php echo $data; ?>
+	var wpseoHelpscoutBeaconL10n = <?php echo $data; ?>;
 
-		if(wpseoHelpscoutBeaconL10n.type === 'no_search'){
-			/* jshint ignore:start */
-			!function(e,o,n){window.HSCW=o,window.HS=n,n.beacon=n.beacon||{};var t=n.beacon;t.userConfig={},t.readyQueue=[],t.config=function(e){this.userConfig=e},t.ready=function(e){this.readyQueue.push(e)},o.config={docs:{enabled:!1,baseUrl:""},contact:{enabled:!0,formId:"8a00db59-227f-11e6-aae8-0a7d6919297d"}};var r=e.getElementsByTagName("script")[0],c=e.createElement("script");c.type="text/javascript",c.async=!0,c.src="https://djtflbt20bdde.cloudfront.net/",r.parentNode.insertBefore(c,r)}(document,window.HSCW||{},window.HS||{});
-			/* jshint ignore:end */
-		}else {
-			/* jshint ignore:start */
-			!function(e,o,n){window.HSCW=o,window.HS=n,n.beacon=n.beacon||{};var t=n.beacon;t.userConfig={},t.readyQueue=[],t.config=function(e){this.userConfig=e},t.ready=function(e){this.readyQueue.push(e)},o.config={docs:{enabled:!0,baseUrl:"//yoast.helpscoutdocs.com/"},contact:{enabled:!0,formId:"f9665afe-77cd-11e5-8846-0e599dc12a51"}};var r=e.getElementsByTagName("script")[0],c=e.createElement("script");c.type="text/javascript",c.async=!0,c.src="https://djtflbt20bdde.cloudfront.net/",r.parentNode.insertBefore(c,r)}(document,window.HSCW||{},window.HS||{});
-			/* jshint ignore:end */
-		}
+
+	if(wpseoHelpscoutBeaconL10n.type === 'no_search'){
+		/* jshint ignore:start */
+		!function(e,o,n){window.HSCW=o,window.HS=n,n.beacon=n.beacon||{};var t=n.beacon;t.userConfig={},t.readyQueue=[],t.config=function(e){this.userConfig=e},t.ready=function(e){this.readyQueue.push(e)},o.config={docs:{enabled:!1,baseUrl:""},contact:{enabled:!0,formId:"8a00db59-227f-11e6-aae8-0a7d6919297d"}};var r=e.getElementsByTagName("script")[0],c=e.createElement("script");c.type="text/javascript",c.async=!0,c.src="https://djtflbt20bdde.cloudfront.net/",r.parentNode.insertBefore(c,r)}(document,window.HSCW||{},window.HS||{});
+		/* jshint ignore:end */
+	}else {
+		/* jshint ignore:start */
+		!function(e,o,n){window.HSCW=o,window.HS=n,n.beacon=n.beacon||{};var t=n.beacon;t.userConfig={},t.readyQueue=[],t.config=function(e){this.userConfig=e},t.ready=function(e){this.readyQueue.push(e)},o.config={docs:{enabled:!0,baseUrl:"//yoast.helpscoutdocs.com/"},contact:{enabled:!0,formId:"f9665afe-77cd-11e5-8846-0e599dc12a51"}};var r=e.getElementsByTagName("script")[0],c=e.createElement("script");c.type="text/javascript",c.async=!0,c.src="https://djtflbt20bdde.cloudfront.net/",r.parentNode.insertBefore(c,r)}(document,window.HSCW||{},window.HS||{});
+		/* jshint ignore:end */
+	}
+
+	HS.beacon.get_helpscout_beacon_identity = function() {
+		return wpseoHelpscoutBeaconL10n.identify;
+	};
 
 	HS.beacon.config( wpseoHelpscoutBeaconL10n.config );
 	HS.beacon.ready(function() {

--- a/src/yoast-seo-helpscout-beacon.js.php
+++ b/src/yoast-seo-helpscout-beacon.js.php
@@ -11,9 +11,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	var wpseoHelpscoutBeaconL10n = <?php echo $data; ?>
 
-	/* jshint ignore:start */
-	!function(e,o,n){window.HSCW=o,window.HS=n,n.beacon=n.beacon||{};var t=n.beacon;t.userConfig={},t.readyQueue=[],t.config=function(e){this.userConfig=e},t.ready=function(e){this.readyQueue.push(e)},o.config={docs:{enabled:!0,baseUrl:"//yoast.helpscoutdocs.com/"},contact:{enabled:!0,formId:"f9665afe-77cd-11e5-8846-0e599dc12a51"}};var r=e.getElementsByTagName("script")[0],c=e.createElement("script");c.type="text/javascript",c.async=!0,c.src="https://djtflbt20bdde.cloudfront.net/",r.parentNode.insertBefore(c,r)}(document,window.HSCW||{},window.HS||{});
-	/* jshint ignore:end */
+		if(wpseoHelpscoutBeaconL10n.type === 'no_search'){
+			/* jshint ignore:start */
+			!function(e,o,n){window.HSCW=o,window.HS=n,n.beacon=n.beacon||{};var t=n.beacon;t.userConfig={},t.readyQueue=[],t.config=function(e){this.userConfig=e},t.ready=function(e){this.readyQueue.push(e)},o.config={docs:{enabled:!1,baseUrl:""},contact:{enabled:!0,formId:"8a00db59-227f-11e6-aae8-0a7d6919297d"}};var r=e.getElementsByTagName("script")[0],c=e.createElement("script");c.type="text/javascript",c.async=!0,c.src="https://djtflbt20bdde.cloudfront.net/",r.parentNode.insertBefore(c,r)}(document,window.HSCW||{},window.HS||{});
+			/* jshint ignore:end */
+		}else {
+			/* jshint ignore:start */
+			!function(e,o,n){window.HSCW=o,window.HS=n,n.beacon=n.beacon||{};var t=n.beacon;t.userConfig={},t.readyQueue=[],t.config=function(e){this.userConfig=e},t.ready=function(e){this.readyQueue.push(e)},o.config={docs:{enabled:!0,baseUrl:"//yoast.helpscoutdocs.com/"},contact:{enabled:!0,formId:"f9665afe-77cd-11e5-8846-0e599dc12a51"}};var r=e.getElementsByTagName("script")[0],c=e.createElement("script");c.type="text/javascript",c.async=!0,c.src="https://djtflbt20bdde.cloudfront.net/",r.parentNode.insertBefore(c,r)}(document,window.HSCW||{},window.HS||{});
+			/* jshint ignore:end */
+		}
 
 	HS.beacon.config( wpseoHelpscoutBeaconL10n.config );
 	HS.beacon.ready(function() {


### PR DESCRIPTION
added another beacon type: "no-search". This type directly opens the contact form when opening the beacon.

Also altered the settings interface to enable custom configuration.

Fixes https://github.com/Yoast/wordpress-seo/issues/4624