### PR TITLE
Remove backwards incompatible code

### DIFF
--- a/src/class-helpscout-beacon.php
+++ b/src/class-helpscout-beacon.php
@@ -223,7 +223,9 @@ class Yoast_HelpScout_Beacon {
 		);
 
 		foreach ( $this->settings as $setting ) {
-			$config = array_merge( $config, $setting->get_config( $page ) );
+			if ( method_exists( $setting, 'get_config' ) ) {
+				$config = array_merge( $config, $setting->get_config( $page ) );
+			}
 		}
 
 		return $config;

--- a/src/interface-helpscout-beacon-setting.php
+++ b/src/interface-helpscout-beacon-setting.php
@@ -19,14 +19,4 @@ interface Yoast_HelpScout_Beacon_Setting {
 	 * @return Yoast_Product[] A product to use for sending data to helpscout
 	 */
 	public function get_products( $page );
-
-
-	/**
-	 * Returns a list of config values for a a certain admin page.
-	 *
-	 * @param string $page The current admin page we are on.
-	 *
-	 * @return array A list with configuration for the beacon
-	 */
-	public function get_config( $page );
 }


### PR DESCRIPTION
This fixed the following bug: When installing Yoast SEO Premium 3.3-beta
and 3.2 of Yoast SEO News you would get fatal errors on all settings
pages. This was caused by the newly introduced method in the interface.