### PR TITLE
Prevent a space as the user's name

### DIFF
--- a/src/class-helpscout-beacon-identifier.php
+++ b/src/class-helpscout-beacon-identifier.php
@@ -105,7 +105,7 @@ class Yoast_HelpScout_Beacon_Identifier {
 				break;
 			case 'name':
 			default:
-				$out = trim($current_user->user_firstname . ' ' . $current_user->user_lastname);
+				$out = trim( $current_user->user_firstname . ' ' . $current_user->user_lastname );
 				break;
 		}
 

--- a/src/class-helpscout-beacon-identifier.php
+++ b/src/class-helpscout-beacon-identifier.php
@@ -105,7 +105,7 @@ class Yoast_HelpScout_Beacon_Identifier {
 				break;
 			case 'name':
 			default:
-				$out = $current_user->user_firstname . ' ' . $current_user->user_lastname;
+				$out = trim($current_user->user_firstname . ' ' . $current_user->user_lastname);
 				break;
 		}
 


### PR DESCRIPTION
If a user doesn't have his first- and lastname set, an empty space will be shown for the user's name. 

![general_-_yoast_seo_ _local_wordpress_dev_ _wordpress](https://cloud.githubusercontent.com/assets/5352634/16305665/20d6f726-395b-11e6-908b-d07a334e0053.png)


![general_-_yoast_seo_ _my_yoast_com_ _wordpress](https://cloud.githubusercontent.com/assets/5352634/16305737/61400078-395b-11e6-831f-1dd5b808dcaa.png)
