### PR TITLE
Wrapped php_uname call in function_exists as per @moorscode's suggestion

### DIFF
--- a/src/class-helpscout-beacon-identifier.php
+++ b/src/class-helpscout-beacon-identifier.php
@@ -59,7 +59,7 @@ class Yoast_HelpScout_Beacon_Identifier {
 			$out .= '<tr><td>Hostname</td><td>' . gethostbyaddr( $ipaddress ) . '</td></tr>';
 		}
 
-		if ( function_exists( 'php_uname' ) {
+		if ( function_exists( 'php_uname' ) ) {
 			$out .= '<tr><td>OS</td><td>' . php_uname( 's r' ) . '</td></tr>';
 		}
 

--- a/src/class-helpscout-beacon-identifier.php
+++ b/src/class-helpscout-beacon-identifier.php
@@ -58,7 +58,11 @@ class Yoast_HelpScout_Beacon_Identifier {
 			$out .= '<tr><td>IP</td><td>' . $ipaddress . '</td></tr>';
 			$out .= '<tr><td>Hostname</td><td>' . gethostbyaddr( $ipaddress ) . '</td></tr>';
 		}
-		$out .= '<tr><td>OS</td><td>' . php_uname( 's r' ) . '</td></tr>';
+
+		if ( function_exists( 'php_uname' ) {
+			$out .= '<tr><td>OS</td><td>' . php_uname( 's r' ) . '</td></tr>';
+		}
+
 		$out .= '<tr><td>PHP</td><td>' . PHP_VERSION . '</td></tr>';
 		$out .= '<tr><td>CURL</td><td>' . $this->get_curl_info() . '</td></tr>';
 		$out .= '</table>';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Wraps `php_uname` call in a `function_exists` to prevent errors on certain server configurations.

Fixes #8 
Fixes https://github.com/Yoast/wordpress-seo/issues/11474