### PR TITLE
Set modal higher z-index.

### DIFF
--- a/src/class-helpscout-beacon.php
+++ b/src/class-helpscout-beacon.php
@@ -220,7 +220,8 @@ class Yoast_HelpScout_Beacon {
 			'color'        => '#A4286A',
 			'poweredBy'    => false,
 			'translation'  => $this->get_translations(),
-			'showSubject' => true,
+			'showSubject'  => true,
+			'zIndex'       => 1000001,
 		);
 
 		foreach ( $this->settings as $setting ) {


### PR DESCRIPTION
Fixes https://github.com/Yoast/wordpress-seo-premium/issues/1057

In the responsive view, some parts of the Help Beacon modal are hidden by the WordPress UI.

Specifically, the WordPress admin bar and admin menu use z-index values up to `99999`. We need to set a higher value for the modal. It it possible to pass a value from the config object, see https://developer.helpscout.com/beacons/customization/#attributes

How to test:
- on master
- in Chrome, emulate a mobile device e.g. iPad portrait view
- go in the Help Center > Get Support > click "New support request"
- the modal opens
- notice there's no way to close the modal because its top part is hidden behind the WordPress top bar
- switch to landscape view
- see the WordPress admin menu covers the left part of the modal

See also the screenshots on the issue https://github.com/Yoast/wordpress-seo-premium/issues/1057

- switch to this branch
- not sure what you have to do to get the new "vendor" package, maybe link the branch in `composer.json` and run `composer install`? Please ask to someone more expert than me
- repeat the steps above
- see the modal is fully visible in both portrait and landscape
- finally, in the modal top right there's a "X" to close the modal

Note: the modal has many accessibility issues, those have been listed in a specific report and are out of the scope of this issue.